### PR TITLE
fix: enforce insights ordering and improve module robustness

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 default_stages: [pre-commit]
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-json
       - id: check-merge-conflict
@@ -19,14 +19,14 @@ repos:
           - --allow-missing-credentials
       - id: detect-private-key
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.98.1
+    rev: v1.105.0
     hooks:
       - id: terraform_fmt
       - id: terraform_tflint
       - id: terraform_docs
       - id: terraform_validate
   - repo: https://github.com/bridgecrewio/checkov.git
-    rev: 3.2.388
+    rev: 3.2.497
     hooks:
       - id: checkov
         verbose: false

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ IMPORTANT: We do not pin modules to versions in our examples. We highly recommen
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.52.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.28.0 |
 
 ## Modules
 
@@ -33,33 +33,36 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_attributes"></a> [attributes](#input\_attributes) | List of nested attribute definitions. Only required for hash\_key and range\_key attributes. Each attribute has two properties: name - (Required) The name of the attribute, type - (Required) Attribute type, which must be a scalar type: S, N, or B for (S)tring, (N)umber or (B)inary data. | `list(map(string))` | n/a | yes |
-| <a name="input_hash_key"></a> [hash\_key](#input\_hash\_key) | The attribute to use as the hash (partition) key. Must also be defined as an attribute | `string` | n/a | yes |
-| <a name="input_kms_key_arn"></a> [kms\_key\_arn](#input\_kms\_key\_arn) | The ARN of the KMS key to use; if set to `null` the `aws/dynamodb` AWS-managed key will be used | `string` | n/a | yes |
-| <a name="input_name"></a> [name](#input\_name) | Name of the DynamoDB table | `string` | n/a | yes |
-| <a name="input_billing_mode"></a> [billing\_mode](#input\_billing\_mode) | Controls how you are billed for read/write throughput and how you manage capacity. The valid values are PROVISIONED or PAY\_PER\_REQUEST. | `string` | `"PAY_PER_REQUEST"` | no |
-| <a name="input_deletion_protection_enabled"></a> [deletion\_protection\_enabled](#input\_deletion\_protection\_enabled) | Enables deletion protection for the table. | `bool` | `true` | no |
-| <a name="input_enable_dynamodb_insights"></a> [enable\_dynamodb\_insights](#input\_enable\_dynamodb\_insights) | Set to true to enable CloudWatch contributor insights for DynamoDB | `bool` | `false` | no |
-| <a name="input_global_secondary_indexes"></a> [global\_secondary\_indexes](#input\_global\_secondary\_indexes) | Describe a GSI for the table; subject to the normal limits on the number of GSIs, projected attributes, etc. | <pre>list(object({<br>    name               = string<br>    hash_key           = string<br>    projection_type    = string<br>    range_key          = optional(string, null)<br>    read_capacity      = optional(string, null)<br>    write_capacity     = optional(string, null)<br>    non_key_attributes = optional(list(string), null)<br>  }))</pre> | `[]` | no |
-| <a name="input_local_secondary_indexes"></a> [local\_secondary\_indexes](#input\_local\_secondary\_indexes) | Describe a LSI on the table; these can only be allocated at creation so you cannot change this definition after you have created the resource. | <pre>list(object({<br>    name               = string<br>    range_key          = string<br>    projection_type    = string<br>    non_key_attributes = optional(list(string), null)<br>  }))</pre> | `[]` | no |
-| <a name="input_point_in_time_recovery_enabled"></a> [point\_in\_time\_recovery\_enabled](#input\_point\_in\_time\_recovery\_enabled) | Set to true to enable point-in-time recovery | `bool` | `true` | no |
-| <a name="input_range_key"></a> [range\_key](#input\_range\_key) | The attribute to use as the range (sort) key. Must also be defined as an attribute | `string` | `null` | no |
-| <a name="input_read_capacity"></a> [read\_capacity](#input\_read\_capacity) | The number of read units for this table. If the billing\_mode is PROVISIONED, this field should be greater than 0 | `number` | `null` | no |
-| <a name="input_replica_regions"></a> [replica\_regions](#input\_replica\_regions) | Region names for creating replicas for a global DynamoDB table including parameters. | <pre>list(object({<br>    region_name            = string<br>    kms_key_arn            = optional(string, null)<br>    propagate_tags         = optional(bool, null)<br>    point_in_time_recovery = optional(bool, null)<br>  }))</pre> | `[]` | no |
-| <a name="input_stream_enabled"></a> [stream\_enabled](#input\_stream\_enabled) | Set to true to enable streams | `bool` | `false` | no |
-| <a name="input_stream_view_type"></a> [stream\_view\_type](#input\_stream\_view\_type) | When an item in the table is modified, StreamViewType determines what information is written to the table's stream. Valid values are KEYS\_ONLY, NEW\_IMAGE, OLD\_IMAGE, NEW\_AND\_OLD\_IMAGES. | `string` | `null` | no |
-| <a name="input_table_class"></a> [table\_class](#input\_table\_class) | The storage class of the table. Valid values are STANDARD and STANDARD\_INFREQUENT\_ACCESS | `string` | `null` | no |
-| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
-| <a name="input_ttl_attribute_name"></a> [ttl\_attribute\_name](#input\_ttl\_attribute\_name) | The name of the table attribute to store the TTL timestamp in | `string` | `""` | no |
-| <a name="input_ttl_enabled"></a> [ttl\_enabled](#input\_ttl\_enabled) | Indicates whether ttl is enabled | `bool` | `false` | no |
-| <a name="input_write_capacity"></a> [write\_capacity](#input\_write\_capacity) | The number of write units for this table. If the billing\_mode is PROVISIONED, this field should be greater than 0 | `number` | `null` | no |
+| <a name="input_attributes"></a> [attributes](#input\_attributes) | List of attribute definitions for keys and indexes. Each item must include: `name` and `type` (S, N, or B). | `list(map(string))` | n/a | yes |
+| <a name="input_billing_mode"></a> [billing\_mode](#input\_billing\_mode) | Billing mode for the table. Valid values: PROVISIONED or PAY\_PER\_REQUEST. | `string` | `"PAY_PER_REQUEST"` | no |
+| <a name="input_deletion_protection_enabled"></a> [deletion\_protection\_enabled](#input\_deletion\_protection\_enabled) | Enable deletion protection for the table. | `bool` | `true` | no |
+| <a name="input_enable_dynamodb_insights"></a> [enable\_dynamodb\_insights](#input\_enable\_dynamodb\_insights) | Enable DynamoDB Contributor Insights for the table. | `bool` | `false` | no |
+| <a name="input_global_secondary_indexes"></a> [global\_secondary\_indexes](#input\_global\_secondary\_indexes) | Global secondary indexes (GSIs). Subject to DynamoDB limits on number of GSIs and projected attributes. | <pre>list(object({<br/>    name               = string<br/>    hash_key           = string<br/>    projection_type    = string<br/>    range_key          = optional(string, null)<br/>    read_capacity      = optional(string, null)<br/>    write_capacity     = optional(string, null)<br/>    non_key_attributes = optional(list(string), null)<br/>  }))</pre> | `[]` | no |
+| <a name="input_hash_key"></a> [hash\_key](#input\_hash\_key) | Partition (hash) key attribute name. Must also be defined in `attributes`. | `string` | n/a | yes |
+| <a name="input_kms_key_arn"></a> [kms\_key\_arn](#input\_kms\_key\_arn) | KMS key ARN used for server-side encryption. If `null`, the AWS-managed key `aws/dynamodb` is used. | `string` | n/a | yes |
+| <a name="input_local_secondary_indexes"></a> [local\_secondary\_indexes](#input\_local\_secondary\_indexes) | Local secondary indexes (LSIs). LSIs can only be set at table creation time. | <pre>list(object({<br/>    name               = string<br/>    range_key          = string<br/>    projection_type    = string<br/>    non_key_attributes = optional(list(string), null)<br/>  }))</pre> | `[]` | no |
+| <a name="input_name"></a> [name](#input\_name) | Name of the DynamoDB table. | `string` | n/a | yes |
+| <a name="input_point_in_time_recovery_enabled"></a> [point\_in\_time\_recovery\_enabled](#input\_point\_in\_time\_recovery\_enabled) | Enable point-in-time recovery (PITR) for the table. | `bool` | `true` | no |
+| <a name="input_range_key"></a> [range\_key](#input\_range\_key) | Sort (range) key attribute name. Must also be defined in `attributes`. | `string` | `null` | no |
+| <a name="input_read_capacity"></a> [read\_capacity](#input\_read\_capacity) | Read capacity units (RCU) when `billing_mode` is `PROVISIONED`. | `number` | `null` | no |
+| <a name="input_replica_regions"></a> [replica\_regions](#input\_replica\_regions) | Replica regions configuration for global tables. | <pre>list(object({<br/>    region_name            = string<br/>    kms_key_arn            = optional(string, null)<br/>    propagate_tags         = optional(bool, null)<br/>    point_in_time_recovery = optional(bool, null)<br/>  }))</pre> | `[]` | no |
+| <a name="input_stream_enabled"></a> [stream\_enabled](#input\_stream\_enabled) | Enable DynamoDB Streams for the table. | `bool` | `false` | no |
+| <a name="input_stream_view_type"></a> [stream\_view\_type](#input\_stream\_view\_type) | Stream view type when streams are enabled. Valid values: `KEYS_ONLY`, `NEW_IMAGE`, `OLD_IMAGE`, `NEW_AND_OLD_IMAGES`. | `string` | `null` | no |
+| <a name="input_table_class"></a> [table\_class](#input\_table\_class) | Table class. Valid values: `STANDARD` or `STANDARD_INFREQUENT_ACCESS`. | `string` | `"STANDARD"` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to all resources. | `map(string)` | `{}` | no |
+| <a name="input_ttl_attribute_name"></a> [ttl\_attribute\_name](#input\_ttl\_attribute\_name) | TTL attribute name (Unix epoch time in seconds). Used only when `ttl_enabled` is true. | `string` | `""` | no |
+| <a name="input_ttl_enabled"></a> [ttl\_enabled](#input\_ttl\_enabled) | Enable Time To Live (TTL) on the table. | `bool` | `false` | no |
+| <a name="input_write_capacity"></a> [write\_capacity](#input\_write\_capacity) | Write capacity units (WCU) when `billing_mode` is `PROVISIONED`. | `number` | `null` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| <a name="output_arn"></a> [arn](#output\_arn) | ARN of the DynamoDB table |
-| <a name="output_id"></a> [id](#output\_id) | ID of the DynamoDB table |
+| <a name="output_arn"></a> [arn](#output\_arn) | ARN of the DynamoDB table. |
+| <a name="output_id"></a> [id](#output\_id) | ID of the DynamoDB table. |
+| <a name="output_name"></a> [name](#output\_name) | Name of the DynamoDB table. |
+| <a name="output_stream_arn"></a> [stream\_arn](#output\_stream\_arn) | ARN of the DynamoDB table stream (empty if streams are disabled). |
+| <a name="output_stream_label"></a> [stream\_label](#output\_stream\_label) | Timestamp label of the DynamoDB table stream (empty if streams are disabled). |
 <!-- END_TF_DOCS -->
 
 ## Licensing

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ IMPORTANT: We do not pin modules to versions in our examples. We highly recommen
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.28.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.52.0 |
 
 ## Modules
 
@@ -34,14 +34,14 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_attributes"></a> [attributes](#input\_attributes) | List of attribute definitions for keys and indexes. Each item must include: `name` and `type` (S, N, or B). | `list(map(string))` | n/a | yes |
+| <a name="input_hash_key"></a> [hash\_key](#input\_hash\_key) | Partition (hash) key attribute name. Must also be defined in `attributes`. | `string` | n/a | yes |
+| <a name="input_kms_key_arn"></a> [kms\_key\_arn](#input\_kms\_key\_arn) | KMS key ARN used for server-side encryption. If `null`, the AWS-managed key `aws/dynamodb` is used. | `string` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | Name of the DynamoDB table. | `string` | n/a | yes |
 | <a name="input_billing_mode"></a> [billing\_mode](#input\_billing\_mode) | Billing mode for the table. Valid values: PROVISIONED or PAY\_PER\_REQUEST. | `string` | `"PAY_PER_REQUEST"` | no |
 | <a name="input_deletion_protection_enabled"></a> [deletion\_protection\_enabled](#input\_deletion\_protection\_enabled) | Enable deletion protection for the table. | `bool` | `true` | no |
 | <a name="input_enable_dynamodb_insights"></a> [enable\_dynamodb\_insights](#input\_enable\_dynamodb\_insights) | Enable DynamoDB Contributor Insights for the table. | `bool` | `false` | no |
 | <a name="input_global_secondary_indexes"></a> [global\_secondary\_indexes](#input\_global\_secondary\_indexes) | Global secondary indexes (GSIs). Subject to DynamoDB limits on number of GSIs and projected attributes. | <pre>list(object({<br/>    name               = string<br/>    hash_key           = string<br/>    projection_type    = string<br/>    range_key          = optional(string, null)<br/>    read_capacity      = optional(string, null)<br/>    write_capacity     = optional(string, null)<br/>    non_key_attributes = optional(list(string), null)<br/>  }))</pre> | `[]` | no |
-| <a name="input_hash_key"></a> [hash\_key](#input\_hash\_key) | Partition (hash) key attribute name. Must also be defined in `attributes`. | `string` | n/a | yes |
-| <a name="input_kms_key_arn"></a> [kms\_key\_arn](#input\_kms\_key\_arn) | KMS key ARN used for server-side encryption. If `null`, the AWS-managed key `aws/dynamodb` is used. | `string` | n/a | yes |
 | <a name="input_local_secondary_indexes"></a> [local\_secondary\_indexes](#input\_local\_secondary\_indexes) | Local secondary indexes (LSIs). LSIs can only be set at table creation time. | <pre>list(object({<br/>    name               = string<br/>    range_key          = string<br/>    projection_type    = string<br/>    non_key_attributes = optional(list(string), null)<br/>  }))</pre> | `[]` | no |
-| <a name="input_name"></a> [name](#input\_name) | Name of the DynamoDB table. | `string` | n/a | yes |
 | <a name="input_point_in_time_recovery_enabled"></a> [point\_in\_time\_recovery\_enabled](#input\_point\_in\_time\_recovery\_enabled) | Enable point-in-time recovery (PITR) for the table. | `bool` | `true` | no |
 | <a name="input_range_key"></a> [range\_key](#input\_range\_key) | Sort (range) key attribute name. Must also be defined in `attributes`. | `string` | `null` | no |
 | <a name="input_read_capacity"></a> [read\_capacity](#input\_read\_capacity) | Read capacity units (RCU) when `billing_mode` is `PROVISIONED`. | `number` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -1,14 +1,20 @@
+
 resource "aws_dynamodb_table" "table" {
   name                        = var.name
   billing_mode                = var.billing_mode
   deletion_protection_enabled = var.deletion_protection_enabled
-  hash_key                    = var.hash_key
-  range_key                   = var.range_key
-  read_capacity               = var.read_capacity
-  stream_enabled              = var.stream_enabled
-  stream_view_type            = var.stream_view_type
-  table_class                 = var.table_class
-  write_capacity              = var.write_capacity
+
+  hash_key  = var.hash_key
+  range_key = var.range_key
+
+  # Only required when billing_mode == PROVISIONED
+  read_capacity  = var.read_capacity
+  write_capacity = var.write_capacity
+
+  stream_enabled   = var.stream_enabled
+  stream_view_type = var.stream_view_type
+
+  table_class = var.table_class
 
   point_in_time_recovery {
     enabled = var.point_in_time_recovery_enabled
@@ -26,7 +32,6 @@ resource "aws_dynamodb_table" "table" {
 
   dynamic "attribute" {
     for_each = var.attributes
-
     content {
       name = attribute.value.name
       type = attribute.value.type
@@ -35,7 +40,6 @@ resource "aws_dynamodb_table" "table" {
 
   dynamic "local_secondary_index" {
     for_each = var.local_secondary_indexes
-
     content {
       name               = local_secondary_index.value.name
       range_key          = local_secondary_index.value.range_key
@@ -46,7 +50,6 @@ resource "aws_dynamodb_table" "table" {
 
   dynamic "global_secondary_index" {
     for_each = var.global_secondary_indexes
-
     content {
       name               = global_secondary_index.value.name
       hash_key           = global_secondary_index.value.hash_key
@@ -60,7 +63,6 @@ resource "aws_dynamodb_table" "table" {
 
   dynamic "replica" {
     for_each = var.replica_regions
-
     content {
       region_name            = replica.value.region_name
       kms_key_arn            = lookup(replica.value, "kms_key_arn", null)
@@ -75,10 +77,43 @@ resource "aws_dynamodb_table" "table" {
       "Name" = format("%s", var.name)
     },
   )
+
+  # DynamoDB operations can be slow when PITR/replicas/indexes are involved.
+  # These timeouts reduce flaky CI applies (especially on first create).
+  timeouts {
+    create = "30m"
+    update = "30m"
+    delete = "30m"
+  }
+
+  lifecycle {
+    # Fast, readable errors for common misconfigurations.
+    precondition {
+      condition     = !var.ttl_enabled || (var.ttl_attribute_name != null && var.ttl_attribute_name != "")
+      error_message = "ttl_attribute_name must be set when ttl_enabled is true."
+    }
+
+    precondition {
+      condition     = !var.stream_enabled || (var.stream_view_type != null && var.stream_view_type != "")
+      error_message = "stream_view_type must be set when stream_enabled is true."
+    }
+
+    precondition {
+      condition = (
+        var.billing_mode != "PROVISIONED"
+        || (var.read_capacity != null && var.write_capacity != null)
+      )
+      error_message = "read_capacity and write_capacity must be set when billing_mode is PROVISIONED."
+    }
+  }
 }
 
 resource "aws_dynamodb_contributor_insights" "table_insight" {
   count = var.enable_dynamodb_insights ? 1 : 0
 
-  table_name = var.name
+  # Reference the table resource to enforce correct creation order.
+  table_name = aws_dynamodb_table.table.name
+
+  # Explicit dependency for clarity and future-proofing (redundant with the reference above).
+  depends_on = [aws_dynamodb_table.table]
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,9 +1,24 @@
+output "name" {
+  description = "Name of the DynamoDB table."
+  value       = aws_dynamodb_table.table.name
+}
+
 output "arn" {
-  description = "ARN of the DynamoDB table"
+  description = "ARN of the DynamoDB table."
   value       = aws_dynamodb_table.table.arn
 }
 
 output "id" {
-  description = "ID of the DynamoDB table"
+  description = "ID of the DynamoDB table."
   value       = aws_dynamodb_table.table.id
+}
+
+output "stream_arn" {
+  description = "ARN of the DynamoDB table stream (empty if streams are disabled)."
+  value       = try(aws_dynamodb_table.table.stream_arn, "")
+}
+
+output "stream_label" {
+  description = "Timestamp label of the DynamoDB table stream (empty if streams are disabled)."
+  value       = try(aws_dynamodb_table.table.stream_label, "")
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,28 +1,98 @@
+############################################
+# Core
+############################################
+
+variable "name" {
+  description = "Name of the DynamoDB table."
+  type        = string
+}
+
+variable "hash_key" {
+  description = "Partition (hash) key attribute name. Must also be defined in `attributes`."
+  type        = string
+}
+
+variable "range_key" {
+  description = "Sort (range) key attribute name. Must also be defined in `attributes`."
+  type        = string
+  default     = null
+}
+
 variable "attributes" {
-  description = "List of nested attribute definitions. Only required for hash_key and range_key attributes. Each attribute has two properties: name - (Required) The name of the attribute, type - (Required) Attribute type, which must be a scalar type: S, N, or B for (S)tring, (N)umber or (B)inary data."
+  description = "List of attribute definitions for keys and indexes. Each item must include: `name` and `type` (S, N, or B)."
   type        = list(map(string))
 }
 
+############################################
+# Encryption & tags
+############################################
+
+variable "kms_key_arn" {
+  description = "KMS key ARN used for server-side encryption. If `null`, the AWS-managed key `aws/dynamodb` is used."
+  type        = string
+}
+
+variable "tags" {
+  description = "Tags to apply to all resources."
+  type        = map(string)
+  default     = {}
+}
+
+############################################
+# Capacity, billing, and storage class
+############################################
+
 variable "billing_mode" {
-  description = "Controls how you are billed for read/write throughput and how you manage capacity. The valid values are PROVISIONED or PAY_PER_REQUEST."
   type        = string
   default     = "PAY_PER_REQUEST"
+  description = "Billing mode for the table. Valid values: PROVISIONED or PAY_PER_REQUEST."
+
+  validation {
+    condition     = contains(["PROVISIONED", "PAY_PER_REQUEST"], var.billing_mode)
+    error_message = "billing_mode must be PROVISIONED or PAY_PER_REQUEST."
+  }
 }
 
-variable "deletion_protection_enabled" {
-  description = "Enables deletion protection for the table."
-  type        = bool
-  default     = true
+variable "read_capacity" {
+  description = "Read capacity units (RCU) when `billing_mode` is `PROVISIONED`."
+  type        = number
+  default     = null
 }
 
-variable "enable_dynamodb_insights" {
-  description = "Set to true to enable CloudWatch contributor insights for DynamoDB"
-  type        = bool
-  default     = false
+variable "write_capacity" {
+  description = "Write capacity units (WCU) when `billing_mode` is `PROVISIONED`."
+  type        = number
+  default     = null
+}
+
+variable "table_class" {
+  description = "Table class. Valid values: `STANDARD` or `STANDARD_INFREQUENT_ACCESS`."
+  type        = string
+  default     = "STANDARD"
+
+  validation {
+    condition     = contains(["STANDARD", "STANDARD_INFREQUENT_ACCESS"], var.table_class)
+    error_message = "table_class must be one of: STANDARD or STANDARD_INFREQUENT_ACCESS."
+  }
+}
+
+############################################
+# Indexes
+############################################
+
+variable "local_secondary_indexes" {
+  description = "Local secondary indexes (LSIs). LSIs can only be set at table creation time."
+  type = list(object({
+    name               = string
+    range_key          = string
+    projection_type    = string
+    non_key_attributes = optional(list(string), null)
+  }))
+  default = []
 }
 
 variable "global_secondary_indexes" {
-  description = "Describe a GSI for the table; subject to the normal limits on the number of GSIs, projected attributes, etc."
+  description = "Global secondary indexes (GSIs). Subject to DynamoDB limits on number of GSIs and projected attributes."
   type = list(object({
     name               = string
     hash_key           = string
@@ -35,53 +105,44 @@ variable "global_secondary_indexes" {
   default = []
 }
 
-variable "hash_key" {
-  description = "The attribute to use as the hash (partition) key. Must also be defined as an attribute"
-  type        = string
-}
+############################################
+# Streams
+############################################
 
-variable "kms_key_arn" {
-  description = "The ARN of the KMS key to use; if set to `null` the `aws/dynamodb` AWS-managed key will be used"
-  type        = string
-}
-
-variable "local_secondary_indexes" {
-  description = "Describe a LSI on the table; these can only be allocated at creation so you cannot change this definition after you have created the resource."
-  type = list(object({
-    name               = string
-    range_key          = string
-    projection_type    = string
-    non_key_attributes = optional(list(string), null)
-  }))
-  default = []
-}
-
-variable "name" {
-  description = "Name of the DynamoDB table"
-  type        = string
-}
-
-variable "point_in_time_recovery_enabled" {
-  description = "Set to true to enable point-in-time recovery"
+variable "stream_enabled" {
+  description = "Enable DynamoDB Streams for the table."
   type        = bool
-  default     = true
+  default     = false
 }
 
-
-variable "range_key" {
-  description = "The attribute to use as the range (sort) key. Must also be defined as an attribute"
+variable "stream_view_type" {
+  description = "Stream view type when streams are enabled. Valid values: `KEYS_ONLY`, `NEW_IMAGE`, `OLD_IMAGE`, `NEW_AND_OLD_IMAGES`."
   type        = string
   default     = null
 }
 
-variable "read_capacity" {
-  description = "The number of read units for this table. If the billing_mode is PROVISIONED, this field should be greater than 0"
-  type        = number
-  default     = null
+############################################
+# TTL
+############################################
+
+variable "ttl_enabled" {
+  description = "Enable Time To Live (TTL) on the table."
+  type        = bool
+  default     = false
 }
+
+variable "ttl_attribute_name" {
+  description = "TTL attribute name (Unix epoch time in seconds). Used only when `ttl_enabled` is true."
+  type        = string
+  default     = ""
+}
+
+############################################
+# Replication (Global Tables)
+############################################
 
 variable "replica_regions" {
-  description = "Region names for creating replicas for a global DynamoDB table including parameters."
+  description = "Replica regions configuration for global tables."
   type = list(object({
     region_name            = string
     kms_key_arn            = optional(string, null)
@@ -91,44 +152,28 @@ variable "replica_regions" {
   default = []
 }
 
-variable "stream_enabled" {
-  description = "Set to true to enable streams"
+############################################
+# Durability & protection
+############################################
+
+variable "point_in_time_recovery_enabled" {
+  description = "Enable point-in-time recovery (PITR) for the table."
+  type        = bool
+  default     = true
+}
+
+variable "deletion_protection_enabled" {
+  description = "Enable deletion protection for the table."
+  type        = bool
+  default     = true
+}
+
+############################################
+# Observability
+############################################
+
+variable "enable_dynamodb_insights" {
+  description = "Enable DynamoDB Contributor Insights for the table."
   type        = bool
   default     = false
-}
-
-variable "stream_view_type" {
-  description = "When an item in the table is modified, StreamViewType determines what information is written to the table's stream. Valid values are KEYS_ONLY, NEW_IMAGE, OLD_IMAGE, NEW_AND_OLD_IMAGES."
-  type        = string
-  default     = null
-}
-
-variable "tags" {
-  description = "A map of tags to add to all resources"
-  type        = map(string)
-  default     = {}
-}
-
-variable "table_class" {
-  description = "The storage class of the table. Valid values are STANDARD and STANDARD_INFREQUENT_ACCESS"
-  type        = string
-  default     = null
-}
-
-variable "ttl_attribute_name" {
-  description = "The name of the table attribute to store the TTL timestamp in"
-  type        = string
-  default     = ""
-}
-
-variable "ttl_enabled" {
-  description = "Indicates whether ttl is enabled"
-  type        = bool
-  default     = false
-}
-
-variable "write_capacity" {
-  description = "The number of write units for this table. If the billing_mode is PROVISIONED, this field should be greater than 0"
-  type        = number
-  default     = null
 }


### PR DESCRIPTION
## :hammer_and_wrench: Summary

Improves the robustness and developer experience of the DynamoDB module, particularly when Contributor Insights is enabled or when creating tables with GSIs, replicas, or PITR.

## :rocket: Motivation

We have seen ResourceNotFoundException errors when enabling Contributor Insights on first apply, caused by Terraform creating the insights resource in parallel with the table.
Additionally, some common misconfigurations (TTL, streams, PROVISIONED capacity) were only caught by AWS at apply time.

## :pencil: Additional Information

Contributor Insights now explicitly depends on the DynamoDB table resource to avoid race conditions.
Lifecycle preconditions provide fast, readable feedback for invalid configurations.
Table operation timeouts improve reliability for tables with GSIs, replicas, or PITR
Variables and outputs were reorganized and documented for clearer usage, with added validation and an explicit default for table_class.
