### PR TITLE
feat: harden table config, add GSI insights, and improve validations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 default_stages: [pre-commit]
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-json
       - id: check-merge-conflict
@@ -19,14 +19,14 @@ repos:
           - --allow-missing-credentials
       - id: detect-private-key
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.98.1
+    rev: v1.105.0
     hooks:
       - id: terraform_fmt
       - id: terraform_tflint
       - id: terraform_docs
       - id: terraform_validate
   - repo: https://github.com/bridgecrewio/checkov.git
-    rev: 3.2.388
+    rev: 3.2.497
     hooks:
       - id: checkov
         verbose: false

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ IMPORTANT: We do not pin modules to versions in our examples. We highly recommen
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.31.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.13.0 |
 
 ## Modules
 
@@ -35,15 +35,15 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_attributes"></a> [attributes](#input\_attributes) | Attribute definitions for table keys and index keys (provider constraint: only key/index attributes may be declared).<br/>Each item must include: `name` and `type` (S, N, or B).<br/><br/>Note: TTL attribute must NOT be declared here unless it is used as a key in an index. | <pre>list(object({<br/>    name = string<br/>    type = string<br/>  }))</pre> | n/a | yes |
+| <a name="input_hash_key"></a> [hash\_key](#input\_hash\_key) | Partition (hash) key attribute name. Must be defined in `attributes`. | `string` | n/a | yes |
+| <a name="input_kms_key_arn"></a> [kms\_key\_arn](#input\_kms\_key\_arn) | KMS key ARN for server-side encryption. When null, AWS-managed key (aws/dynamodb) is used. | `string` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | DynamoDB table name. | `string` | n/a | yes |
 | <a name="input_billing_mode"></a> [billing\_mode](#input\_billing\_mode) | Billing mode: PROVISIONED or PAY\_PER\_REQUEST. | `string` | `"PAY_PER_REQUEST"` | no |
 | <a name="input_deletion_protection_enabled"></a> [deletion\_protection\_enabled](#input\_deletion\_protection\_enabled) | Enable deletion protection. | `bool` | `true` | no |
 | <a name="input_enable_dynamodb_insights"></a> [enable\_dynamodb\_insights](#input\_enable\_dynamodb\_insights) | Enable DynamoDB Contributor Insights. | `bool` | `false` | no |
 | <a name="input_enable_dynamodb_insights_gsis"></a> [enable\_dynamodb\_insights\_gsis](#input\_enable\_dynamodb\_insights\_gsis) | Enable Contributor Insights on all GSIs. | `bool` | `false` | no |
 | <a name="input_global_secondary_indexes"></a> [global\_secondary\_indexes](#input\_global\_secondary\_indexes) | Global secondary indexes (GSIs). | <pre>list(object({<br/>    name            = string<br/>    hash_key        = string<br/>    projection_type = string<br/>    range_key       = optional(string, null)<br/><br/>    read_capacity  = optional(number, null)<br/>    write_capacity = optional(number, null)<br/><br/>    non_key_attributes = optional(list(string), null)<br/><br/>    on_demand_throughput = optional(object({<br/>      max_read_request_units  = optional(number, null)<br/>      max_write_request_units = optional(number, null)<br/>    }), null)<br/><br/>    warm_throughput = optional(object({<br/>      read_units_per_second  = optional(number, null)<br/>      write_units_per_second = optional(number, null)<br/>    }), null)<br/>  }))</pre> | `[]` | no |
-| <a name="input_hash_key"></a> [hash\_key](#input\_hash\_key) | Partition (hash) key attribute name. Must be defined in `attributes`. | `string` | n/a | yes |
-| <a name="input_kms_key_arn"></a> [kms\_key\_arn](#input\_kms\_key\_arn) | KMS key ARN for server-side encryption. When null, AWS-managed key (aws/dynamodb) is used. | `string` | n/a | yes |
 | <a name="input_local_secondary_indexes"></a> [local\_secondary\_indexes](#input\_local\_secondary\_indexes) | Local secondary indexes (LSIs). Only settable at table creation time. | <pre>list(object({<br/>    name               = string<br/>    range_key          = string<br/>    projection_type    = string<br/>    non_key_attributes = optional(list(string), null)<br/>  }))</pre> | `[]` | no |
-| <a name="input_name"></a> [name](#input\_name) | DynamoDB table name. | `string` | n/a | yes |
 | <a name="input_point_in_time_recovery_enabled"></a> [point\_in\_time\_recovery\_enabled](#input\_point\_in\_time\_recovery\_enabled) | Enable point-in-time recovery (PITR). | `bool` | `true` | no |
 | <a name="input_point_in_time_recovery_period_in_days"></a> [point\_in\_time\_recovery\_period\_in\_days](#input\_point\_in\_time\_recovery\_period\_in\_days) | PITR recovery period in days (1..35). | `number` | `35` | no |
 | <a name="input_range_key"></a> [range\_key](#input\_range\_key) | Sort (range) key attribute name (optional). Must be defined in `attributes` when set. | `string` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ IMPORTANT: We do not pin modules to versions in our examples. We highly recommen
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.13.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.31.0 |
 
 ## Modules
 
@@ -26,6 +26,7 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [aws_dynamodb_contributor_insights.gsi_insights](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_contributor_insights) | resource |
 | [aws_dynamodb_contributor_insights.table_insight](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_contributor_insights) | resource |
 | [aws_dynamodb_table.table](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table) | resource |
 
@@ -33,36 +34,41 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_attributes"></a> [attributes](#input\_attributes) | List of nested attribute definitions. Only required for hash\_key and range\_key attributes. Each attribute has two properties: name - (Required) The name of the attribute, type - (Required) Attribute type, which must be a scalar type: S, N, or B for (S)tring, (N)umber or (B)inary data. | `list(map(string))` | n/a | yes |
-| <a name="input_hash_key"></a> [hash\_key](#input\_hash\_key) | The attribute to use as the hash (partition) key. Must also be defined as an attribute | `string` | n/a | yes |
-| <a name="input_kms_key_arn"></a> [kms\_key\_arn](#input\_kms\_key\_arn) | The ARN of the KMS key to use; if set to `null` the `aws/dynamodb` AWS-managed key will be used | `string` | n/a | yes |
-| <a name="input_name"></a> [name](#input\_name) | Name of the DynamoDB table | `string` | n/a | yes |
-| <a name="input_billing_mode"></a> [billing\_mode](#input\_billing\_mode) | Controls how you are billed for read/write throughput and how you manage capacity. The valid values are PROVISIONED or PAY\_PER\_REQUEST. | `string` | `"PAY_PER_REQUEST"` | no |
-| <a name="input_deletion_protection_enabled"></a> [deletion\_protection\_enabled](#input\_deletion\_protection\_enabled) | Enables deletion protection for the table. | `bool` | `true` | no |
-| <a name="input_enable_dynamodb_insights"></a> [enable\_dynamodb\_insights](#input\_enable\_dynamodb\_insights) | Set to true to enable CloudWatch contributor insights for DynamoDB | `bool` | `false` | no |
-| <a name="input_global_secondary_indexes"></a> [global\_secondary\_indexes](#input\_global\_secondary\_indexes) | Describe a GSI for the table; subject to the normal limits on the number of GSIs, projected attributes, etc. | <pre>list(object({<br/>    name               = string<br/>    hash_key           = string<br/>    projection_type    = string<br/>    range_key          = optional(string, null)<br/>    read_capacity      = optional(string, null)<br/>    write_capacity     = optional(string, null)<br/>    non_key_attributes = optional(list(string), null)<br/>    on_demand_throughput = optional(object({<br/>      max_read_request_units  = optional(number, null)<br/>      max_write_request_units = optional(number, null)<br/>    }), null)<br/>    warm_throughput = optional(object({<br/>      read_units_per_second  = optional(number, null)<br/>      write_units_per_second = optional(number, null)<br/>    }), null)<br/>  }))</pre> | `[]` | no |
-| <a name="input_local_secondary_indexes"></a> [local\_secondary\_indexes](#input\_local\_secondary\_indexes) | Describe a LSI on the table; these can only be allocated at creation so you cannot change this definition after you have created the resource. | <pre>list(object({<br/>    name               = string<br/>    range_key          = string<br/>    projection_type    = string<br/>    non_key_attributes = optional(list(string), null)<br/>  }))</pre> | `[]` | no |
-| <a name="input_point_in_time_recovery_enabled"></a> [point\_in\_time\_recovery\_enabled](#input\_point\_in\_time\_recovery\_enabled) | Set to true to enable point-in-time recovery | `bool` | `true` | no |
-| <a name="input_point_in_time_recovery_period_in_days"></a> [point\_in\_time\_recovery\_period\_in\_days](#input\_point\_in\_time\_recovery\_period\_in\_days) | The recovery period in days for point-in-time recovery. Must be between 1 and 35. Default is 35. | `number` | `35` | no |
-| <a name="input_range_key"></a> [range\_key](#input\_range\_key) | The attribute to use as the range (sort) key. Must also be defined as an attribute | `string` | `null` | no |
-| <a name="input_read_capacity"></a> [read\_capacity](#input\_read\_capacity) | The number of read units for this table. If the billing\_mode is PROVISIONED, this field should be greater than 0 | `number` | `null` | no |
-| <a name="input_replica_regions"></a> [replica\_regions](#input\_replica\_regions) | Region names for creating replicas for a global DynamoDB table including parameters. | <pre>list(object({<br/>    region_name                 = string<br/>    kms_key_arn                 = optional(string, null)<br/>    propagate_tags              = optional(bool, null)<br/>    point_in_time_recovery      = optional(bool, null)<br/>    consistency_mode            = optional(string, null)<br/>    deletion_protection_enabled = optional(bool, null)<br/>  }))</pre> | `[]` | no |
-| <a name="input_stream_enabled"></a> [stream\_enabled](#input\_stream\_enabled) | Set to true to enable streams | `bool` | `false` | no |
-| <a name="input_stream_view_type"></a> [stream\_view\_type](#input\_stream\_view\_type) | When an item in the table is modified, StreamViewType determines what information is written to the table's stream. Valid values are KEYS\_ONLY, NEW\_IMAGE, OLD\_IMAGE, NEW\_AND\_OLD\_IMAGES. | `string` | `null` | no |
-| <a name="input_table_class"></a> [table\_class](#input\_table\_class) | The storage class of the table. Valid values are STANDARD and STANDARD\_INFREQUENT\_ACCESS | `string` | `null` | no |
-| <a name="input_table_on_demand_throughput"></a> [table\_on\_demand\_throughput](#input\_table\_on\_demand\_throughput) | Sets the maximum number of read and write units for when the table is in on-demand mode. Set to -1 to remove the cap. | <pre>object({<br/>    max_read_request_units  = optional(number, null)<br/>    max_write_request_units = optional(number, null)<br/>  })</pre> | `null` | no |
-| <a name="input_table_warm_throughput"></a> [table\_warm\_throughput](#input\_table\_warm\_throughput) | Sets the warm throughput for the table. Minimum values are read\_units\_per\_second: 12000, write\_units\_per\_second: 4000. | <pre>object({<br/>    read_units_per_second  = optional(number, null)<br/>    write_units_per_second = optional(number, null)<br/>  })</pre> | `null` | no |
-| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
-| <a name="input_ttl_attribute_name"></a> [ttl\_attribute\_name](#input\_ttl\_attribute\_name) | The name of the table attribute to store the TTL timestamp in | `string` | `""` | no |
-| <a name="input_ttl_enabled"></a> [ttl\_enabled](#input\_ttl\_enabled) | Indicates whether ttl is enabled | `bool` | `false` | no |
-| <a name="input_write_capacity"></a> [write\_capacity](#input\_write\_capacity) | The number of write units for this table. If the billing\_mode is PROVISIONED, this field should be greater than 0 | `number` | `null` | no |
+| <a name="input_attributes"></a> [attributes](#input\_attributes) | Attribute definitions for table keys and index keys (provider constraint: only key/index attributes may be declared).<br/>Each item must include: `name` and `type` (S, N, or B).<br/><br/>Note: TTL attribute must NOT be declared here unless it is used as a key in an index. | <pre>list(object({<br/>    name = string<br/>    type = string<br/>  }))</pre> | n/a | yes |
+| <a name="input_billing_mode"></a> [billing\_mode](#input\_billing\_mode) | Billing mode: PROVISIONED or PAY\_PER\_REQUEST. | `string` | `"PAY_PER_REQUEST"` | no |
+| <a name="input_deletion_protection_enabled"></a> [deletion\_protection\_enabled](#input\_deletion\_protection\_enabled) | Enable deletion protection. | `bool` | `true` | no |
+| <a name="input_enable_dynamodb_insights"></a> [enable\_dynamodb\_insights](#input\_enable\_dynamodb\_insights) | Enable DynamoDB Contributor Insights. | `bool` | `false` | no |
+| <a name="input_enable_dynamodb_insights_gsis"></a> [enable\_dynamodb\_insights\_gsis](#input\_enable\_dynamodb\_insights\_gsis) | Enable Contributor Insights on all GSIs. | `bool` | `false` | no |
+| <a name="input_global_secondary_indexes"></a> [global\_secondary\_indexes](#input\_global\_secondary\_indexes) | Global secondary indexes (GSIs). | <pre>list(object({<br/>    name            = string<br/>    hash_key        = string<br/>    projection_type = string<br/>    range_key       = optional(string, null)<br/><br/>    read_capacity  = optional(number, null)<br/>    write_capacity = optional(number, null)<br/><br/>    non_key_attributes = optional(list(string), null)<br/><br/>    on_demand_throughput = optional(object({<br/>      max_read_request_units  = optional(number, null)<br/>      max_write_request_units = optional(number, null)<br/>    }), null)<br/><br/>    warm_throughput = optional(object({<br/>      read_units_per_second  = optional(number, null)<br/>      write_units_per_second = optional(number, null)<br/>    }), null)<br/>  }))</pre> | `[]` | no |
+| <a name="input_hash_key"></a> [hash\_key](#input\_hash\_key) | Partition (hash) key attribute name. Must be defined in `attributes`. | `string` | n/a | yes |
+| <a name="input_kms_key_arn"></a> [kms\_key\_arn](#input\_kms\_key\_arn) | KMS key ARN for server-side encryption. When null, AWS-managed key (aws/dynamodb) is used. | `string` | n/a | yes |
+| <a name="input_local_secondary_indexes"></a> [local\_secondary\_indexes](#input\_local\_secondary\_indexes) | Local secondary indexes (LSIs). Only settable at table creation time. | <pre>list(object({<br/>    name               = string<br/>    range_key          = string<br/>    projection_type    = string<br/>    non_key_attributes = optional(list(string), null)<br/>  }))</pre> | `[]` | no |
+| <a name="input_name"></a> [name](#input\_name) | DynamoDB table name. | `string` | n/a | yes |
+| <a name="input_point_in_time_recovery_enabled"></a> [point\_in\_time\_recovery\_enabled](#input\_point\_in\_time\_recovery\_enabled) | Enable point-in-time recovery (PITR). | `bool` | `true` | no |
+| <a name="input_point_in_time_recovery_period_in_days"></a> [point\_in\_time\_recovery\_period\_in\_days](#input\_point\_in\_time\_recovery\_period\_in\_days) | PITR recovery period in days (1..35). | `number` | `35` | no |
+| <a name="input_range_key"></a> [range\_key](#input\_range\_key) | Sort (range) key attribute name (optional). Must be defined in `attributes` when set. | `string` | `null` | no |
+| <a name="input_read_capacity"></a> [read\_capacity](#input\_read\_capacity) | Read capacity units (RCU) when billing\_mode is PROVISIONED. | `number` | `null` | no |
+| <a name="input_replica_regions"></a> [replica\_regions](#input\_replica\_regions) | Replica regions configuration for global tables. | <pre>list(object({<br/>    region_name                 = string<br/>    kms_key_arn                 = optional(string, null)<br/>    propagate_tags              = optional(bool, null)<br/>    point_in_time_recovery      = optional(bool, null)<br/>    consistency_mode            = optional(string, null)<br/>    deletion_protection_enabled = optional(bool, null)<br/>  }))</pre> | `[]` | no |
+| <a name="input_stream_enabled"></a> [stream\_enabled](#input\_stream\_enabled) | Enable DynamoDB Streams. | `bool` | `false` | no |
+| <a name="input_stream_view_type"></a> [stream\_view\_type](#input\_stream\_view\_type) | Stream view type when streams are enabled: KEYS\_ONLY, NEW\_IMAGE, OLD\_IMAGE, NEW\_AND\_OLD\_IMAGES. | `string` | `null` | no |
+| <a name="input_table_class"></a> [table\_class](#input\_table\_class) | Table class: STANDARD or STANDARD\_INFREQUENT\_ACCESS. | `string` | `"STANDARD"` | no |
+| <a name="input_table_on_demand_throughput"></a> [table\_on\_demand\_throughput](#input\_table\_on\_demand\_throughput) | Optional caps for on-demand mode. Set -1 to remove the cap (module/provider semantics dependent). | <pre>object({<br/>    max_read_request_units  = optional(number, null)<br/>    max_write_request_units = optional(number, null)<br/>  })</pre> | `null` | no |
+| <a name="input_table_warm_throughput"></a> [table\_warm\_throughput](#input\_table\_warm\_throughput) | Optional warm throughput settings (if supported). | <pre>object({<br/>    read_units_per_second  = optional(number, null)<br/>    write_units_per_second = optional(number, null)<br/>  })</pre> | `null` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Tags applied to all resources. | `map(string)` | `{}` | no |
+| <a name="input_ttl_attribute_name"></a> [ttl\_attribute\_name](#input\_ttl\_attribute\_name) | TTL attribute name (Unix epoch time in seconds). Used only when ttl\_enabled is true. | `string` | `"ttl"` | no |
+| <a name="input_ttl_enabled"></a> [ttl\_enabled](#input\_ttl\_enabled) | Enable Time To Live (TTL). | `bool` | `false` | no |
+| <a name="input_write_capacity"></a> [write\_capacity](#input\_write\_capacity) | Write capacity units (WCU) when billing\_mode is PROVISIONED. | `number` | `null` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| <a name="output_arn"></a> [arn](#output\_arn) | ARN of the DynamoDB table |
-| <a name="output_id"></a> [id](#output\_id) | ID of the DynamoDB table |
+| <a name="output_arn"></a> [arn](#output\_arn) | ARN of the DynamoDB table. |
+| <a name="output_gsi_names"></a> [gsi\_names](#output\_gsi\_names) | List of GSI names. |
+| <a name="output_id"></a> [id](#output\_id) | ID of the DynamoDB table. |
+| <a name="output_name"></a> [name](#output\_name) | Name of the DynamoDB table. |
+| <a name="output_stream_arn"></a> [stream\_arn](#output\_stream\_arn) | ARN of the DynamoDB table stream (empty if streams are disabled). |
+| <a name="output_stream_label"></a> [stream\_label](#output\_stream\_label) | Timestamp label of the DynamoDB table stream (empty if streams are disabled). |
 <!-- END_TF_DOCS -->
 
 ## Licensing

--- a/main.tf
+++ b/main.tf
@@ -1,18 +1,46 @@
+locals {
+  attribute_names     = toset([for a in var.attributes : a.name])
+  attribute_name_list = [for a in var.attributes : a.name]
+
+  table_key_names = toset(compact([var.hash_key, var.range_key]))
+
+  gsi_key_names = toset(flatten([
+    for g in var.global_secondary_indexes :
+    compact([g.hash_key, try(g.range_key, null)])
+  ]))
+
+  lsi_key_names = toset([
+    for l in var.local_secondary_indexes : l.range_key
+  ])
+
+  all_key_names = setunion(local.table_key_names, local.gsi_key_names, local.lsi_key_names)
+
+  missing_key_attributes = setsubtract(local.all_key_names, local.attribute_names)
+}
+
+
+
+
 resource "aws_dynamodb_table" "table" {
   name                        = var.name
   billing_mode                = var.billing_mode
   deletion_protection_enabled = var.deletion_protection_enabled
-  hash_key                    = var.hash_key
-  range_key                   = var.range_key
-  read_capacity               = var.read_capacity
-  stream_enabled              = var.stream_enabled
-  stream_view_type            = var.stream_view_type
-  table_class                 = var.table_class
-  write_capacity              = var.write_capacity
+
+  hash_key  = var.hash_key
+  range_key = var.range_key
+
+  # Only required when billing_mode == PROVISIONED
+  read_capacity  = var.billing_mode == "PROVISIONED" ? var.read_capacity : null
+  write_capacity = var.billing_mode == "PROVISIONED" ? var.write_capacity : null
+
+  stream_enabled   = var.stream_enabled
+  stream_view_type = var.stream_view_type
+
+  table_class = var.table_class
 
   point_in_time_recovery {
     enabled                 = var.point_in_time_recovery_enabled
-    recovery_period_in_days = var.point_in_time_recovery_period_in_days
+    recovery_period_in_days = var.point_in_time_recovery_enabled ? var.point_in_time_recovery_period_in_days : null
   }
 
   server_side_encryption {
@@ -20,9 +48,12 @@ resource "aws_dynamodb_table" "table" {
     kms_key_arn = var.kms_key_arn
   }
 
-  ttl {
-    enabled        = var.ttl_enabled
-    attribute_name = var.ttl_attribute_name
+  dynamic "ttl" {
+    for_each = var.ttl_enabled ? [1] : []
+    content {
+      enabled        = true
+      attribute_name = var.ttl_attribute_name
+    }
   }
 
   dynamic "on_demand_throughput" {
@@ -45,7 +76,6 @@ resource "aws_dynamodb_table" "table" {
 
   dynamic "attribute" {
     for_each = var.attributes
-
     content {
       name = attribute.value.name
       type = attribute.value.type
@@ -54,7 +84,6 @@ resource "aws_dynamodb_table" "table" {
 
   dynamic "local_secondary_index" {
     for_each = var.local_secondary_indexes
-
     content {
       name               = local_secondary_index.value.name
       range_key          = local_secondary_index.value.range_key
@@ -65,15 +94,14 @@ resource "aws_dynamodb_table" "table" {
 
   dynamic "global_secondary_index" {
     for_each = var.global_secondary_indexes
-
     content {
       name               = global_secondary_index.value.name
       hash_key           = global_secondary_index.value.hash_key
       projection_type    = global_secondary_index.value.projection_type
       range_key          = lookup(global_secondary_index.value, "range_key", null)
-      read_capacity      = lookup(global_secondary_index.value, "read_capacity", null)
-      write_capacity     = lookup(global_secondary_index.value, "write_capacity", null)
       non_key_attributes = lookup(global_secondary_index.value, "non_key_attributes", null)
+      read_capacity      = var.billing_mode == "PROVISIONED" ? lookup(global_secondary_index.value, "read_capacity", null) : null
+      write_capacity     = var.billing_mode == "PROVISIONED" ? lookup(global_secondary_index.value, "write_capacity", null) : null
 
       dynamic "on_demand_throughput" {
         for_each = lookup(global_secondary_index.value, "on_demand_throughput", null) != null ? [global_secondary_index.value.on_demand_throughput] : []
@@ -97,7 +125,6 @@ resource "aws_dynamodb_table" "table" {
 
   dynamic "replica" {
     for_each = var.replica_regions
-
     content {
       region_name                 = replica.value.region_name
       kms_key_arn                 = lookup(replica.value, "kms_key_arn", null)
@@ -114,12 +141,70 @@ resource "aws_dynamodb_table" "table" {
       "Name" = format("%s", var.name)
     },
   )
+
+  # DynamoDB operations can be slow when PITR/replicas/indexes are involved.
+  # These timeouts reduce flaky CI applies (especially on first create).
+  timeouts {
+    create = "30m"
+    update = "30m"
+    delete = "30m"
+  }
+
+  lifecycle {
+    # Fast, readable errors for common misconfigurations.
+    precondition {
+      condition     = !var.ttl_enabled || (var.ttl_attribute_name != null && var.ttl_attribute_name != "")
+      error_message = "ttl_attribute_name must be set when ttl_enabled is true."
+    }
+
+    precondition {
+      condition     = !var.stream_enabled || (var.stream_view_type != null && var.stream_view_type != "")
+      error_message = "stream_view_type must be set when stream_enabled is true."
+    }
+
+    precondition {
+      condition = (
+        var.billing_mode != "PROVISIONED"
+        || (var.read_capacity != null && var.write_capacity != null)
+      )
+      error_message = "read_capacity and write_capacity must be set when billing_mode is PROVISIONED."
+    }
+
+    precondition {
+      condition     = length(local.missing_key_attributes) == 0
+      error_message = "Missing attribute definitions for keys/indexes: ${join(", ", tolist(local.missing_key_attributes))}. Add them to var.attributes."
+    }
+
+    precondition {
+      condition     = length(local.attribute_name_list) == length(toset(local.attribute_name_list))
+      error_message = "Duplicate attribute names found in var.attributes."
+    }
+
+    precondition {
+      condition = (
+        length(var.replica_regions) == 0
+        || (var.stream_enabled && var.stream_view_type == "NEW_AND_OLD_IMAGES")
+      )
+      error_message = "Global Tables (replica_regions) require stream_enabled = true and stream_view_type = 'NEW_AND_OLD_IMAGES'."
+    }
+  }
 }
 
 resource "aws_dynamodb_contributor_insights" "table_insight" {
   count = var.enable_dynamodb_insights ? 1 : 0
 
+  # Reference the table resource to enforce correct creation order.
   table_name = aws_dynamodb_table.table.name
 
+  # Explicit dependency for clarity and future-proofing (redundant with the reference above).
   depends_on = [aws_dynamodb_table.table]
+}
+
+resource "aws_dynamodb_contributor_insights" "gsi_insights" {
+  for_each = var.enable_dynamodb_insights_gsis ? {
+    for g in var.global_secondary_indexes : g.name => g
+  } : {}
+
+  table_name = aws_dynamodb_table.table.name
+  index_name = each.key
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,9 +1,29 @@
+output "name" {
+  description = "Name of the DynamoDB table."
+  value       = aws_dynamodb_table.table.name
+}
+
 output "arn" {
-  description = "ARN of the DynamoDB table"
+  description = "ARN of the DynamoDB table."
   value       = aws_dynamodb_table.table.arn
 }
 
 output "id" {
-  description = "ID of the DynamoDB table"
+  description = "ID of the DynamoDB table."
   value       = aws_dynamodb_table.table.id
+}
+
+output "stream_arn" {
+  description = "ARN of the DynamoDB table stream (empty if streams are disabled)."
+  value       = try(aws_dynamodb_table.table.stream_arn, "")
+}
+
+output "stream_label" {
+  description = "Timestamp label of the DynamoDB table stream (empty if streams are disabled)."
+  value       = try(aws_dynamodb_table.table.stream_label, "")
+}
+
+output "gsi_names" {
+  value       = [for g in var.global_secondary_indexes : g.name]
+  description = "List of GSI names."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,106 +1,184 @@
-variable "attributes" {
-  description = "List of nested attribute definitions. Only required for hash_key and range_key attributes. Each attribute has two properties: name - (Required) The name of the attribute, type - (Required) Attribute type, which must be a scalar type: S, N, or B for (S)tring, (N)umber or (B)inary data."
-  type        = list(map(string))
-}
+############################################
+# Table identity & keys
+############################################
 
-variable "billing_mode" {
-  description = "Controls how you are billed for read/write throughput and how you manage capacity. The valid values are PROVISIONED or PAY_PER_REQUEST."
+variable "name" {
   type        = string
-  default     = "PAY_PER_REQUEST"
-}
-
-variable "deletion_protection_enabled" {
-  description = "Enables deletion protection for the table."
-  type        = bool
-  default     = true
-}
-
-variable "enable_dynamodb_insights" {
-  description = "Set to true to enable CloudWatch contributor insights for DynamoDB"
-  type        = bool
-  default     = false
-}
-
-variable "global_secondary_indexes" {
-  description = "Describe a GSI for the table; subject to the normal limits on the number of GSIs, projected attributes, etc."
-  type = list(object({
-    name               = string
-    hash_key           = string
-    projection_type    = string
-    range_key          = optional(string, null)
-    read_capacity      = optional(string, null)
-    write_capacity     = optional(string, null)
-    non_key_attributes = optional(list(string), null)
-    on_demand_throughput = optional(object({
-      max_read_request_units  = optional(number, null)
-      max_write_request_units = optional(number, null)
-    }), null)
-    warm_throughput = optional(object({
-      read_units_per_second  = optional(number, null)
-      write_units_per_second = optional(number, null)
-    }), null)
-  }))
-  default = []
+  description = "DynamoDB table name."
 }
 
 variable "hash_key" {
-  description = "The attribute to use as the hash (partition) key. Must also be defined as an attribute"
   type        = string
+  description = "Partition (hash) key attribute name. Must be defined in `attributes`."
 }
 
-variable "kms_key_arn" {
-  description = "The ARN of the KMS key to use; if set to `null` the `aws/dynamodb` AWS-managed key will be used"
+variable "range_key" {
   type        = string
+  default     = null
+  description = "Sort (range) key attribute name (optional). Must be defined in `attributes` when set."
 }
+
+variable "attributes" {
+  type = list(object({
+    name = string
+    type = string
+  }))
+
+  description = <<-EOT
+  Attribute definitions for table keys and index keys (provider constraint: only key/index attributes may be declared).
+  Each item must include: `name` and `type` (S, N, or B).
+
+  Note: TTL attribute must NOT be declared here unless it is used as a key in an index.
+  EOT
+
+  validation {
+    condition     = alltrue([for a in var.attributes : contains(["S", "N", "B"], a.type)])
+    error_message = "attributes[*].type must be one of: S, N, B."
+  }
+}
+
+############################################
+# Billing & throughput
+############################################
+
+variable "billing_mode" {
+  type        = string
+  default     = "PAY_PER_REQUEST"
+  description = "Billing mode: PROVISIONED or PAY_PER_REQUEST."
+
+  validation {
+    condition     = contains(["PROVISIONED", "PAY_PER_REQUEST"], var.billing_mode)
+    error_message = "billing_mode must be PROVISIONED or PAY_PER_REQUEST."
+  }
+}
+
+variable "read_capacity" {
+  type        = number
+  default     = null
+  description = "Read capacity units (RCU) when billing_mode is PROVISIONED."
+}
+
+variable "write_capacity" {
+  type        = number
+  default     = null
+  description = "Write capacity units (WCU) when billing_mode is PROVISIONED."
+}
+
+variable "table_class" {
+  type        = string
+  default     = "STANDARD"
+  description = "Table class: STANDARD or STANDARD_INFREQUENT_ACCESS."
+
+  validation {
+    condition     = contains(["STANDARD", "STANDARD_INFREQUENT_ACCESS"], var.table_class)
+    error_message = "table_class must be STANDARD or STANDARD_INFREQUENT_ACCESS."
+  }
+}
+
+variable "table_on_demand_throughput" {
+  type = object({
+    max_read_request_units  = optional(number, null)
+    max_write_request_units = optional(number, null)
+  })
+  default     = null
+  description = "Optional caps for on-demand mode. Set -1 to remove the cap (module/provider semantics dependent)."
+}
+
+variable "table_warm_throughput" {
+  type = object({
+    read_units_per_second  = optional(number, null)
+    write_units_per_second = optional(number, null)
+  })
+  default     = null
+  description = "Optional warm throughput settings (if supported)."
+}
+
+############################################
+# Indexes
+############################################
 
 variable "local_secondary_indexes" {
-  description = "Describe a LSI on the table; these can only be allocated at creation so you cannot change this definition after you have created the resource."
   type = list(object({
     name               = string
     range_key          = string
     projection_type    = string
     non_key_attributes = optional(list(string), null)
   }))
-  default = []
+  default     = []
+  description = "Local secondary indexes (LSIs). Only settable at table creation time."
 }
 
-variable "name" {
-  description = "Name of the DynamoDB table"
-  type        = string
+variable "global_secondary_indexes" {
+  type = list(object({
+    name            = string
+    hash_key        = string
+    projection_type = string
+    range_key       = optional(string, null)
+
+    read_capacity  = optional(number, null)
+    write_capacity = optional(number, null)
+
+    non_key_attributes = optional(list(string), null)
+
+    on_demand_throughput = optional(object({
+      max_read_request_units  = optional(number, null)
+      max_write_request_units = optional(number, null)
+    }), null)
+
+    warm_throughput = optional(object({
+      read_units_per_second  = optional(number, null)
+      write_units_per_second = optional(number, null)
+    }), null)
+  }))
+  default     = []
+  description = "Global secondary indexes (GSIs)."
 }
 
-variable "point_in_time_recovery_enabled" {
-  description = "Set to true to enable point-in-time recovery"
+############################################
+# Streams
+############################################
+
+variable "stream_enabled" {
   type        = bool
-  default     = true
+  default     = false
+  description = "Enable DynamoDB Streams."
 }
 
-variable "point_in_time_recovery_period_in_days" {
-  description = "The recovery period in days for point-in-time recovery. Must be between 1 and 35. Default is 35."
-  type        = number
-  default     = 35
+variable "stream_view_type" {
+  type        = string
+  default     = null
+  description = "Stream view type when streams are enabled: KEYS_ONLY, NEW_IMAGE, OLD_IMAGE, NEW_AND_OLD_IMAGES."
 
   validation {
-    condition     = var.point_in_time_recovery_period_in_days >= 1 && var.point_in_time_recovery_period_in_days <= 35
-    error_message = "The point_in_time_recovery_period_in_days must be between 1 and 35 days."
+    condition = (
+      var.stream_view_type == null ||
+      contains(["KEYS_ONLY", "NEW_IMAGE", "OLD_IMAGE", "NEW_AND_OLD_IMAGES"], var.stream_view_type)
+    )
+    error_message = "stream_view_type must be one of: KEYS_ONLY, NEW_IMAGE, OLD_IMAGE, NEW_AND_OLD_IMAGES."
   }
 }
 
+############################################
+# TTL
+############################################
 
-variable "range_key" {
-  description = "The attribute to use as the range (sort) key. Must also be defined as an attribute"
+variable "ttl_enabled" {
+  type        = bool
+  default     = false
+  description = "Enable Time To Live (TTL)."
+}
+
+variable "ttl_attribute_name" {
   type        = string
-  default     = null
+  default     = "ttl"
+  description = "TTL attribute name (Unix epoch time in seconds). Used only when ttl_enabled is true."
 }
 
-variable "read_capacity" {
-  description = "The number of read units for this table. If the billing_mode is PROVISIONED, this field should be greater than 0"
-  type        = number
-  default     = null
-}
+############################################
+# Replication (Global Tables)
+############################################
 
 variable "replica_regions" {
-  description = "Region names for creating replicas for a global DynamoDB table including parameters."
   type = list(object({
     region_name                 = string
     kms_key_arn                 = optional(string, null)
@@ -109,74 +187,72 @@ variable "replica_regions" {
     consistency_mode            = optional(string, null)
     deletion_protection_enabled = optional(bool, null)
   }))
-  default = []
+  default     = []
+  description = "Replica regions configuration for global tables."
 
   validation {
     condition = alltrue([
-      for replica in var.replica_regions :
-      replica.consistency_mode == null ||
-      contains(["STRONG", "EVENTUAL"], replica.consistency_mode)
+      for r in var.replica_regions :
+      r.consistency_mode == null || contains(["STRONG", "EVENTUAL"], r.consistency_mode)
     ])
-    error_message = "consistency_mode must be either 'STRONG' or 'EVENTUAL'."
+    error_message = "replica_regions[*].consistency_mode must be STRONG or EVENTUAL when set."
   }
 }
 
-variable "stream_enabled" {
-  description = "Set to true to enable streams"
+############################################
+# Durability & protection
+############################################
+
+variable "point_in_time_recovery_enabled" {
   type        = bool
-  default     = false
+  default     = true
+  description = "Enable point-in-time recovery (PITR)."
 }
 
-variable "stream_view_type" {
-  description = "When an item in the table is modified, StreamViewType determines what information is written to the table's stream. Valid values are KEYS_ONLY, NEW_IMAGE, OLD_IMAGE, NEW_AND_OLD_IMAGES."
+variable "point_in_time_recovery_period_in_days" {
+  type        = number
+  default     = 35
+  description = "PITR recovery period in days (1..35)."
+
+  validation {
+    condition     = var.point_in_time_recovery_period_in_days >= 1 && var.point_in_time_recovery_period_in_days <= 35
+    error_message = "point_in_time_recovery_period_in_days must be between 1 and 35."
+  }
+}
+
+variable "deletion_protection_enabled" {
+  type        = bool
+  default     = true
+  description = "Enable deletion protection."
+}
+
+############################################
+# Observability
+############################################
+
+variable "enable_dynamodb_insights" {
+  type        = bool
+  default     = false
+  description = "Enable DynamoDB Contributor Insights."
+}
+
+variable "enable_dynamodb_insights_gsis" {
+  type        = bool
+  default     = false
+  description = "Enable Contributor Insights on all GSIs."
+}
+
+############################################
+# Encryption & tags
+############################################
+
+variable "kms_key_arn" {
   type        = string
-  default     = null
+  description = "KMS key ARN for server-side encryption. When null, AWS-managed key (aws/dynamodb) is used."
 }
 
 variable "tags" {
-  description = "A map of tags to add to all resources"
   type        = map(string)
   default     = {}
-}
-
-variable "table_class" {
-  description = "The storage class of the table. Valid values are STANDARD and STANDARD_INFREQUENT_ACCESS"
-  type        = string
-  default     = null
-}
-
-variable "table_on_demand_throughput" {
-  description = "Sets the maximum number of read and write units for when the table is in on-demand mode. Set to -1 to remove the cap."
-  type = object({
-    max_read_request_units  = optional(number, null)
-    max_write_request_units = optional(number, null)
-  })
-  default = null
-}
-
-variable "table_warm_throughput" {
-  description = "Sets the warm throughput for the table. Minimum values are read_units_per_second: 12000, write_units_per_second: 4000."
-  type = object({
-    read_units_per_second  = optional(number, null)
-    write_units_per_second = optional(number, null)
-  })
-  default = null
-}
-
-variable "ttl_attribute_name" {
-  description = "The name of the table attribute to store the TTL timestamp in"
-  type        = string
-  default     = ""
-}
-
-variable "ttl_enabled" {
-  description = "Indicates whether ttl is enabled"
-  type        = bool
-  default     = false
-}
-
-variable "write_capacity" {
-  description = "The number of write units for this table. If the billing_mode is PROVISIONED, this field should be greater than 0"
-  type        = number
-  default     = null
+  description = "Tags applied to all resources."
 }


### PR DESCRIPTION
## :hammer_and_wrench: Summary

This PR improves the DynamoDB module’s robustness. It adds input validations and fast-fail preconditions, makes capacity/TTL/PITR handling conditional on the selected features, adds optional Contributor Insights for GSIs and introduces clearer outputs.

## :rocket: Motivation

Reduce flaky applies and confusing misconfigurations (missing key attributes, invalid stream/TTL settings, PROVISIONED capacity wiring), while extending the module with GSI Contributor Insights.

This is necessary preparations to support autoscaling.

## :pencil: Additional Information

Key changes:
- read_capacity / write_capacity are only applied when billing_mode = PROVISIONED.
- TTL block is only created when ttl_enabled = true.
- PITR recovery_period_in_days is only set when PITR is enabled.
- Added lifecycle preconditions for common invalid setups (TTL name missing, streams missing view type, PROVISIONED missing capacities, missing/duplicate attribute definitions, Global Tables requiring streams + NEW_AND_OLD_IMAGES).
- New variable enable_dynamodb_insights_gsis creates aws_dynamodb_contributor_insights per GSI.
- Added outputs: name, stream_arn, stream_label, gsi_names.
